### PR TITLE
Tseitin encoding optimizations

### DIFF
--- a/Examples/PigeonHole.lean
+++ b/Examples/PigeonHole.lean
@@ -33,8 +33,7 @@ def encoding (n) : VEncCNF (Var n) Unit (fun τ =>
   ]
   |>.mapProp (by
     ext τ
-    simp [holesWithPigeon, Clause.satisfies_iff, LitVar.satisfies_iff
-        , LitVar.toVar, LitVar.polarity]
+    simp [holesWithPigeon, Clause.satisfies_iff, LitVar.satisfies_iff]
   )
 
 def main (args : List String) : IO Unit := do

--- a/Trestle/Data/ICnf.lean
+++ b/Trestle/Data/ICnf.lean
@@ -49,12 +49,17 @@ end IVar
 def ILit := { i : Int // i ≠ 0 }
   deriving DecidableEq, Repr
 
+instance : OfNat ILit (n+1) := ⟨n+1, by omega⟩
+
 instance : LitVar ILit IVar where
   negate l := ⟨-l.val, Int.neg_ne_zero.mpr l.property⟩
   mkPos x := ⟨Int.ofNat x.val, by simp⟩
   mkNeg x := ⟨-Int.ofNat x.val, by simp⟩
   toVar l := ⟨Int.natAbs l.val, Int.natAbs_pos.mpr l.property⟩
   polarity l := (0 : Int) < l.val
+
+instance : Neg ILit where
+  neg := LitVar.negate
 
 open LitVar in
 theorem polarity_eq {l₁ l₂ : ILit} :

--- a/Trestle/Data/Literal.lean
+++ b/Trestle/Data/Literal.lean
@@ -12,6 +12,7 @@ namespace Trestle
 structure Literal (ν : Type u) : Type u where
   toVar : ν
   polarity : Bool
+deriving Repr
 
 namespace Literal
 

--- a/Trestle/Data/Literal.lean
+++ b/Trestle/Data/Literal.lean
@@ -31,5 +31,5 @@ instance : LawfulLitVar (Literal ν) ν where
   polarity_mkNeg := by aesop
   ext := by intro l1 l2; cases l1; cases l2; aesop
 
-abbrev pos : ν → Literal ν := LitVar.mkPos
-abbrev neg : ν → Literal ν := LitVar.mkNeg
+@[simp] abbrev pos : ν → Literal ν := LitVar.mkPos
+@[simp] abbrev neg : ν → Literal ν := LitVar.mkNeg

--- a/Trestle/Data/Literal.lean
+++ b/Trestle/Data/Literal.lean
@@ -31,5 +31,5 @@ instance : LawfulLitVar (Literal ν) ν where
   polarity_mkNeg := by aesop
   ext := by intro l1 l2; cases l1; cases l2; aesop
 
-abbrev pos : ν → Literal ν := (.mk · true)
-abbrev neg : ν → Literal ν := (.mk · false)
+abbrev pos : ν → Literal ν := LitVar.mkPos
+abbrev neg : ν → Literal ν := LitVar.mkNeg

--- a/Trestle/Encode/Tseitin.lean
+++ b/Trestle/Encode/Tseitin.lean
@@ -180,16 +180,16 @@ open PropFun in
 /-- Tseitin encoding in the general case creates temporaries for each clause -/
 def encodeNNF_mkDefs [LitVar L ν] [LitVar L' ν'] [LawfulLitVar L ν] [DecidableEq ν]
         (t : ν) (emb : ν' ↪ ν) (f : NegNormForm L')
-  : VEncCNF ν Unit (fun τ => τ t ↔ τ ⊨ f.toPropFun.map emb) :=
+  : VEncCNF ν Unit (fun τ => τ t → τ ⊨ f.toPropFun.map emb) :=
   match f with
   | .tr =>
-      addClause #[LitVar.mkPos t]
-      |>.mapProp (by simp [Clause.toPropFun, PropFun.any])
+      VEncCNF.pure ()
+      |>.mapProp (by simp; rfl)
   | .fls =>
       addClause #[LitVar.mkNeg t]
       |>.mapProp (by simp [Clause.toPropFun, PropFun.any])
   | .lit l =>
-      biImpl (LitVar.mkPos t) (LitVar.map emb l)
+      imply (LitVar.mkPos t) (LitVar.map emb l)
       |>.mapProp (by simp)
   | .all as =>
       withTemps as.size (
@@ -198,7 +198,7 @@ def encodeNNF_mkDefs [LitVar L ν] [LitVar L' ν'] [LawfulLitVar L ν] [Decidabl
             encodeNNF_mkDefs (L := Literal _)
               (.inr i) (emb.trans ⟨Sum.inl,Sum.inl_injective⟩) (as[i.val]'i.isLt)
           )
-        , defConj (Literal.pos <| Sum.inl t) (Array.ofFn (Literal.pos <| Sum.inr ·))
+        , implyAnd (Literal.pos <| Sum.inl t) (Array.ofFn (Literal.pos <| Sum.inr ·))
         ]
       ) |>.mapProp (by
         ext τ
@@ -223,7 +223,7 @@ def encodeNNF_mkDefs [LitVar L ν] [LitVar L' ν'] [LawfulLitVar L ν] [Decidabl
             encodeNNF_mkDefs (L := Literal _)
               (.inr i) (emb.trans ⟨Sum.inl,Sum.inl_injective⟩) (as[i.val]'i.isLt)
           )
-        , defDisj (Literal.pos <| Sum.inl t) (Array.ofFn (Literal.pos <| Sum.inr ·))
+        , implyOr (Literal.pos <| Sum.inl t) (Array.ofFn (Literal.pos <| Sum.inr ·))
         ]
       ) |>.mapProp (by
         ext τ

--- a/Trestle/Encode/Tseitin.lean
+++ b/Trestle/Encode/Tseitin.lean
@@ -32,6 +32,18 @@ namespace NegNormForm
 
 variable [LitVar L ν]
 
+def toPropForm (r : NegNormForm L) : PropForm ν :=
+  match r with
+  | .all as => PropForm.conj' (
+      as.attach.map (fun ⟨x,_h⟩ => toPropForm x)
+    ).toList
+  | .any as => PropForm.disj' (
+      as.attach.map (fun ⟨x,_h⟩ => toPropForm x)
+    ).toList
+  | .lit l => LitVar.toPropForm l
+  | .tr => .tr
+  | .fls => .fls
+
 def toPropFun (r : NegNormForm L) : PropFun ν :=
   match r with
   | .all as => PropFun.all (as.attach.map (fun ⟨x,_h⟩ =>

--- a/Trestle/Encode/Tseitin.lean
+++ b/Trestle/Encode/Tseitin.lean
@@ -311,7 +311,7 @@ def encodeNNF
       let separated := separateLits as
       let lits := separated.1
       let subfs := separated.2
-      withTemps subfs.size (
+      withTemps (Fin subfs.size) (
         seq[
           encodeNNF_mkDefs subfs emb
         , implyOr (Literal.pos <| Sum.inl t)
@@ -385,7 +385,7 @@ def encodeNNF_top_clause (f : NegNormForm ν)
   let separated := separateLits disjs
   let lits := separated.1
   let subfs := separated.2
-  withTemps subfs.size (
+  withTemps (Fin subfs.size) (
     seq[
       encodeNNF_mkDefs (ν := ν) subfs ⟨id, fun _ _ h => h⟩
     , addClause (lits.map (LitVar.map Sum.inl) ++ Array.ofFn (Literal.pos <| Sum.inr ·))

--- a/Trestle/Encode/Tseitin.lean
+++ b/Trestle/Encode/Tseitin.lean
@@ -256,6 +256,10 @@ def encodeNNF
       imply (LitVar.mkPos t) (LitVar.map emb l)
       |>.mapProp (by simp)
   | .all as =>
+      -- TODO(JG): this can be further optimized!!!
+      -- we do not need new temps here, because PG only requires `t -> f`
+      -- so for temps I can directly require `t -> all lits`,
+      -- and for each subformula I can just call `encodeNNF` with `t` again!
       let separated := separateLits as
       let lits := separated.1
       let subfs := separated.2

--- a/Trestle/Model/PropForm.lean
+++ b/Trestle/Model/PropForm.lean
@@ -51,7 +51,7 @@ instance [ToString ν] : ToString (PropForm ν) :=
 
 instance : Coe L (PropForm L) := ⟨.var⟩
 
-def conj' (fs : List (PropForm L)) : PropForm L :=
+def all (fs : List (PropForm L)) : PropForm L :=
   match fs.foldr (init := none) (fun f =>
     fun
     | none => some f
@@ -60,7 +60,10 @@ def conj' (fs : List (PropForm L)) : PropForm L :=
   | none => .tr
   | some f => f
 
-def disj' (fs : List (PropForm L)) : PropForm L :=
+@[deprecated all (since := "20 Jan 2025")]
+abbrev conj' (fs : List (PropForm L)) : PropForm L := all fs
+
+def any (fs : List (PropForm L)) : PropForm L :=
   match fs.foldr (init := none) (fun f =>
     fun
     | none => some f
@@ -68,6 +71,9 @@ def disj' (fs : List (PropForm L)) : PropForm L :=
   ) with
   | none => .fls
   | some f => f
+
+@[deprecated any (since := "20 Jan 2025")]
+abbrev disj' (fs : List (PropForm L)) : PropForm L := any fs
 
 /-- The unique extension of `τ` from variables to formulas. -/
 @[simp]

--- a/Trestle/Upstream/ToMathlib.lean
+++ b/Trestle/Upstream/ToMathlib.lean
@@ -386,3 +386,6 @@ theorem le_iff_inf_compl_eq_bot : a ≤ b ↔ a ⊓ bᶜ = ⊥ := by
   rw [← le_bot_iff]; exact le_iff_inf_compl_le_bot
 
 end BooleanAlgebra
+
+@[simp]
+theorem Function.Embedding.coe_refl {α} : ⇑(Function.Embedding.refl α) = id := rfl

--- a/Trestle/Upstream/ToStd.lean
+++ b/Trestle/Upstream/ToStd.lean
@@ -199,7 +199,21 @@ theorem Array.foldl_append (f : β → α → β) (init : β) (A B : Array α) :
 @[simp] theorem Array.size_set! (A : Array α) (i : Nat) (v : α) : (A.set! i v).size = A.size := by
   rw [set!, Array.size_setIfInBounds]
 
+@[simp]
+theorem Array.mem_ofFn {a : α} {f : Fin n → α}
+  : a ∈ Array.ofFn f ↔ ∃ i, f i = a := by
+  simp [Array.mem_iff_getElem, Fin.exists_iff]
+
 /-! List -/
+
+open List in
+theorem List.Sublist.sizeOf_le [SizeOf α] {L₁ L₂ : List α} :
+        L₁ <+ L₂ → sizeOf L₁ ≤ sizeOf L₂ := by
+  intro h
+  induction h
+  · simp
+  · simp; omega
+  · simp; assumption
 
 def List.distinct [DecidableEq α] (L : List α) : List α :=
   L.foldl (·.insert ·) []


### PR DESCRIPTION
current verified tseitin implementation is the basic binary tree encoding.

This PR implements:
- a negation-normal-form pass, with n-ary conjunction/disjunction nodes
- Plaisted-Greenbaum (encoding is equisat but not equiv to the original formula)
- special handling to avoid definitions which are a single literal

Together, these significantly clean up the output, and results in optimal encodings for lots of inputs.

Since the entire transformation is verified, we can avoid justifying these optimizations over and over elsewhere.

For example, the Keller graphs encoding has clauses of the form

$$\bigvee_{j',k} x_{i,j',k} \neq x_{i',j',k}$$

With the above optimizations, we can write this directly in our encoding and get the same optimized CNF as in the paper. We avoid ever reasoning about the optimized format in our proof-code.
