### PR TITLE
feat: generalize withTemps to arbitrary IndexType

### DIFF
--- a/Trestle/Encode/Cardinality/AMO.lean
+++ b/Trestle/Encode/Cardinality/AMO.lean
@@ -81,8 +81,8 @@ def amoSeqCounter (lits : Array (Literal ν)) (k : Nat := 3) (hk : k ≥ 2 := by
     (fun _ =>
       let first_k_lits := lits.take k |>.map <| LitVar.map Sum.inl
       let rest := lits.extract k lits.size |>.map <| LitVar.map Sum.inl
-      let tmp := Sum.inr 0
-      withTemps 1 (
+      let tmp := Sum.inr ()
+      withTemps Unit (
         seq[
           amoPairwise <| first_k_lits.push <| LitVar.mkPos tmp
         , amoSeqCounter (k := k) (hk := hk) <| #[LitVar.mkNeg tmp] ++ rest
@@ -98,7 +98,7 @@ def amoSeqCounter (lits : Array (Literal ν)) (k : Nat := 3) (hk : k ≥ 2 := by
       · intro hτ
         simp at hτ
         rcases hτ with ⟨σ,rfl, hσ₁, hσ₂⟩
-        by_cases h_tmp : σ (Sum.inr 0)
+        by_cases h_tmp : σ (Sum.inr ())
         all_goals (
           try simp only [Fin.isValue, Bool.not_eq_true] at h_tmp
           simp [h_tmp, ← List.map_take, ← List.map_drop] at hσ₁ hσ₂
@@ -115,7 +115,7 @@ def amoSeqCounter (lits : Array (Literal ν)) (k : Nat := 3) (hk : k ≥ 2 := by
         simp at h_amo
         simp [← List.map_take, ← List.map_drop]
         -- CC: TODO have a `set` or `pmap` on assignments for sums
-        let τ' : PropAssignment (ν ⊕ Fin 1) := (fun
+        let τ' : PropAssignment (ν ⊕ Unit) := (fun
             | Sum.inl v => τ v
             | Sum.inr v => card ↑(List.take k (list)) τ = 0)
         have h_eq : τ' ∘ Sum.inl = τ := rfl

--- a/Trestle/Encode/Tseitin.lean
+++ b/Trestle/Encode/Tseitin.lean
@@ -140,7 +140,7 @@ def encodeNNF_mkDefs (t : ν) (emb : ν' ↪ ν) (f : NegNormForm ν')
       biImpl (LitVar.mkPos t) (LitVar.map emb l)
       |>.mapProp (by simp)
   | .and a b =>
-      withTemps 2 (
+      withTemps (Fin 2) (
         seq[
           encodeNNF_mkDefs
             (.inr 0) (emb.trans ⟨Sum.inl,Sum.inl_injective⟩) a
@@ -162,7 +162,7 @@ def encodeNNF_mkDefs (t : ν) (emb : ν' ↪ ν) (f : NegNormForm ν')
             | .inr 1 => τ.map emb ⊨ b.toPropFun
           aesop)
   | .or a b =>
-      withTemps 2 (
+      withTemps (Fin 2) (
         seq[
           encodeNNF_mkDefs
             (.inr 0) (emb.trans ⟨Sum.inl,Sum.inl_injective⟩) a
@@ -193,7 +193,7 @@ def encodeNNF (f : NegNormForm ν) : VEncCNF ν Unit (· ⊨ f.toPropFun) :=
   | .and a b =>
     seq[ encodeNNF a, encodeNNF b].mapProp (by simp)
   | .or a b =>
-    withTemps 2 (
+    withTemps (Fin 2) (
       seq[ encodeNNF_mkDefs (.inr 0) ⟨Sum.inl,Sum.inl_injective⟩ a
         ,  encodeNNF_mkDefs (.inr 1) ⟨Sum.inl,Sum.inl_injective⟩ b
         ,  addClause #[LitVar.mkPos (.inr 0), LitVar.mkPos (.inr 1)]

--- a/Trestle/Encode/VEncCNF.lean
+++ b/Trestle/Encode/VEncCNF.lean
@@ -169,15 +169,15 @@ def assuming (ls : Array (Literal ν)) (e : VEncCNF ν α P)
 open PropFun in
 set_option pp.proofs.withType false in
 @[inline]
-def withTemps (n) {P : PropAssignment (ν ⊕ Fin n) → Prop}
-    (ve : VEncCNF (ν ⊕ Fin n) α P) :
+def withTemps (ι) [IndexType ι] [LawfulIndexType ι] {P : PropAssignment (ν ⊕ ι) → Prop}
+    (ve : VEncCNF (ν ⊕ ι) α P) :
     VEncCNF ν α (fun τ => ∃ σ, τ = σ.map Sum.inl ∧ P σ) :=
   ⟨EncCNF.withTemps _ ve.1, by
     intro ls_pre ls_post'
     -- give various expressions names and specialize hypotheses
     have def_ls_post : ls_post' = Prod.snd _ := rfl
     generalize ls_post' = ls_post at *; clear ls_post'
-    generalize def_ls_post_pair : (EncCNF.withTemps n ve.1).1 ls_pre = ls_post_pair
+    generalize def_ls_post_pair : (EncCNF.withTemps ι ve.1).1 ls_pre = ls_post_pair
       at def_ls_post
     unfold EncCNF.withTemps at def_ls_post_pair
     simp (config := {zeta := false}) at def_ls_post_pair
@@ -188,7 +188,7 @@ def withTemps (n) {P : PropAssignment (ν ⊕ Fin n) → Prop}
     generalize_proofs h
     subst def_ls_post_pair
     simp [vMap, assumeVars] at def_ls_post; clear vMap assumeVars
-    generalize def_ls_pre_temps : LawfulState.withTemps ls_pre = ls_pre_temps
+    generalize def_ls_pre_temps : LawfulState.withTemps (ι := ι) ls_pre = ls_pre_temps
     rw [def_ls_pre_temps] at def_pair
     -- extract relationship between ls_pre_temps and ls_post_temps
     have ls_temps_nextVar := ve.1.2 ls_pre_temps
@@ -213,7 +213,7 @@ def withTemps (n) {P : PropAssignment (ν ⊕ Fin n) → Prop}
         . rcases h2 h with ⟨σ, rfl, _⟩
           use σ; simp
           tauto
-        . let σ : PropAssignment (ν ⊕ Fin n) := fun | .inl x => τ x | _ => false
+        . let σ : PropAssignment (ν ⊕ ι) := fun | .inl x => τ x | _ => false
           use σ
           have : τ = PropAssignment.map Sum.inl σ := funext fun x => by simp only [PropAssignment.get_map]
           tauto

--- a/Trestle/Upstream/IndexType.lean
+++ b/Trestle/Upstream/IndexType.lean
@@ -173,6 +173,10 @@ theorem mem_toList_univ [IndexType α] [LawfulIndexType α] (x) : x ∈ (toList 
 instance (priority := default) : DecidableEq ι := by
   intro x y; rw [← toFin_eq_iff]; infer_instance
 
+instance : Fintype ι where
+  elems := (toList ι).toFinset
+  complete := by simp
+
 
 /-! #### Transport over equivalence -/
 


### PR DESCRIPTION
I know I said I wanted to make the library *less* dependent on IndexType but it's really nice to put `Fin n \x Fin m` instead of `Fin (n * m)` if you need a block of temporaries...